### PR TITLE
Restore CV page arrow navigation

### DIFF
--- a/src/components/ArrowIcon.astro
+++ b/src/components/ArrowIcon.astro
@@ -13,6 +13,8 @@ const ariaLabel =
 
 <button
   type="button"
+  data-experience-nav
+  data-direction={direction}
   class={`bg-transparent border-none p-0 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded-full ${direction === "up" ? "mb-6 invisible more-up" : "more-down"}`}
   aria-label={ariaLabel}
 >

--- a/src/components/ArrowIcon.astro
+++ b/src/components/ArrowIcon.astro
@@ -13,7 +13,7 @@ const ariaLabel =
 
 <button
   type="button"
-  class={`bg-transparent border-none p-0 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded-full ${direction === "up" ? "top-[-40px] invisible more-up" : "top-0 more-down"} absolute`}
+  class={`bg-transparent border-none p-0 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 rounded-full ${direction === "up" ? "mb-6 invisible more-up" : "more-down"}`}
   aria-label={ariaLabel}
 >
   <svg

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -87,74 +87,72 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
         return;
       }
 
-      const getCurrentSectionIndex = () => {
-        const containerRect = mainContainer.getBoundingClientRect();
-        let closestIndex = 0;
-        let smallestDistance = Number.POSITIVE_INFINITY;
+      let sectionPositions = sections.map((section) => section.offsetTop);
+      let activeIndex = 0;
 
-        sections.forEach((section, index) => {
-          const sectionRect = section.getBoundingClientRect();
-          const distance = Math.abs(sectionRect.top - containerRect.top);
-
-          if (distance < smallestDistance) {
-            smallestDistance = distance;
-            closestIndex = index;
-          }
-        });
-
-        return closestIndex;
+      const setArrowVisibility = (index: number) => {
+        moreUpButton.classList.toggle("invisible", index === 0);
+        moreDownButton.classList.toggle(
+          "invisible",
+          index === sections.length - 1
+        );
       };
 
-      const updateArrowVisibility = () => {
-        const currentIndex = getCurrentSectionIndex();
-        const isAtFirstSection = currentIndex === 0;
-        const isAtLastSection = currentIndex === sections.length - 1;
+      const getSectionPositions = () =>
+        sections.map((section) => section.offsetTop);
 
-        if (isAtFirstSection) {
-          moreUpButton.classList.add("invisible");
-        } else {
-          moreUpButton.classList.remove("invisible");
-        }
+      const scrollToIndex = (index: number) => {
+        const targetPosition = sectionPositions[index];
 
-        if (isAtLastSection) {
-          moreDownButton.classList.add("invisible");
-        } else {
-          moreDownButton.classList.remove("invisible");
-        }
-      };
-
-      const scrollToSection = (targetIndex: number) => {
-        const targetSection = sections[targetIndex];
-
-        if (!targetSection) {
+        if (typeof targetPosition !== "number") {
           return;
         }
 
-        targetSection.scrollIntoView({
-          behavior: "smooth",
-          block: "center"
-        });
+        activeIndex = index;
+        setArrowVisibility(index);
 
-        window.requestAnimationFrame(() => {
-          updateArrowVisibility();
+        mainContainer.scrollTo({
+          top: targetPosition,
+          behavior: "smooth"
         });
       };
 
-      const scrollToNextSection = () => {
-        const currentIndex = getCurrentSectionIndex();
-        const nextIndex = Math.min(currentIndex + 1, sections.length - 1);
+      const updateActiveIndexFromScroll = () => {
+        const scrollMiddle = mainContainer.scrollTop + mainContainer.clientHeight / 2;
+        let newIndex = 0;
 
-        if (nextIndex !== currentIndex) {
-          scrollToSection(nextIndex);
+        for (let index = 0; index < sectionPositions.length; index += 1) {
+          if (scrollMiddle >= sectionPositions[index]) {
+            newIndex = index;
+          } else {
+            break;
+          }
+        }
+
+        if (newIndex !== activeIndex) {
+          activeIndex = newIndex;
+          setArrowVisibility(newIndex);
+        }
+      };
+
+      const handleResize = () => {
+        sectionPositions = getSectionPositions();
+        updateActiveIndexFromScroll();
+      };
+
+      const scrollToNextSection = () => {
+        const nextIndex = Math.min(activeIndex + 1, sections.length - 1);
+
+        if (nextIndex !== activeIndex) {
+          scrollToIndex(nextIndex);
         }
       };
 
       const scrollToPreviousSection = () => {
-        const currentIndex = getCurrentSectionIndex();
-        const previousIndex = Math.max(currentIndex - 1, 0);
+        const previousIndex = Math.max(activeIndex - 1, 0);
 
-        if (previousIndex !== currentIndex) {
-          scrollToSection(previousIndex);
+        if (previousIndex !== activeIndex) {
+          scrollToIndex(previousIndex);
         }
       };
 
@@ -168,52 +166,38 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
         }
       };
 
-      let scrollAnimationFrame: number | undefined;
-
       const handleScroll = () => {
-        if (scrollAnimationFrame) {
-          return;
-        }
-
-        scrollAnimationFrame = window.requestAnimationFrame(() => {
-          updateArrowVisibility();
-          scrollAnimationFrame = undefined;
-        });
+        updateActiveIndexFromScroll();
       };
 
       const handleArrowClick = (event: MouseEvent) => {
-        const target = (event.target as HTMLElement | null)?.closest<HTMLButtonElement>(
-          "[data-experience-nav]"
-        );
-
-        if (!target) {
-          return;
-        }
-
         event.preventDefault();
 
-        if (target.dataset.direction === "down") {
+        if (event.currentTarget === moreDownButton) {
           scrollToNextSection();
         } else {
           scrollToPreviousSection();
         }
       };
 
-      document.addEventListener("click", handleArrowClick);
+      moreDownButton.addEventListener("click", handleArrowClick);
+      moreUpButton.addEventListener("click", handleArrowClick);
       document.addEventListener("keydown", handleKeyDown);
       mainContainer.addEventListener("scroll", handleScroll, { passive: true });
+      window.addEventListener("resize", handleResize);
 
-      updateArrowVisibility();
+      window.requestAnimationFrame(() => {
+        sectionPositions = getSectionPositions();
+        updateActiveIndexFromScroll();
+        setArrowVisibility(activeIndex);
+      });
 
       const cleanup = () => {
-        if (scrollAnimationFrame) {
-          window.cancelAnimationFrame(scrollAnimationFrame);
-          scrollAnimationFrame = undefined;
-        }
-
-        document.removeEventListener("click", handleArrowClick);
+        moreDownButton.removeEventListener("click", handleArrowClick);
+        moreUpButton.removeEventListener("click", handleArrowClick);
         document.removeEventListener("keydown", handleKeyDown);
         mainContainer.removeEventListener("scroll", handleScroll);
+        window.removeEventListener("resize", handleResize);
       };
 
       document.addEventListener(

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -66,8 +66,12 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
     "astro:page-load",
     () => {
       const mainContainer = document.querySelector<HTMLElement>(".main-container");
-      const moreDownButton = document.querySelector<HTMLButtonElement>(".more-down");
-      const moreUpButton = document.querySelector<HTMLButtonElement>(".more-up");
+      const moreDownButton = document.querySelector<HTMLButtonElement>(
+        '[data-direction="down"]'
+      );
+      const moreUpButton = document.querySelector<HTMLButtonElement>(
+        '[data-direction="up"]'
+      );
 
       if (!mainContainer || !moreDownButton || !moreUpButton) {
         console.error("One or more elements could not be found in the document.");
@@ -84,12 +88,13 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
       }
 
       const getCurrentSectionIndex = () => {
-        const { scrollTop } = mainContainer;
+        const containerRect = mainContainer.getBoundingClientRect();
         let closestIndex = 0;
         let smallestDistance = Number.POSITIVE_INFINITY;
 
         sections.forEach((section, index) => {
-          const distance = Math.abs(section.offsetTop - scrollTop);
+          const sectionRect = section.getBoundingClientRect();
+          const distance = Math.abs(sectionRect.top - containerRect.top);
 
           if (distance < smallestDistance) {
             smallestDistance = distance;
@@ -125,9 +130,9 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
           return;
         }
 
-        mainContainer.scrollTo({
-          top: targetSection.offsetTop,
-          behavior: "smooth"
+        targetSection.scrollIntoView({
+          behavior: "smooth",
+          block: "center"
         });
 
         window.requestAnimationFrame(() => {
@@ -176,8 +181,25 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
         });
       };
 
-      moreDownButton.addEventListener("click", scrollToNextSection);
-      moreUpButton.addEventListener("click", scrollToPreviousSection);
+      const handleArrowClick = (event: MouseEvent) => {
+        const target = (event.target as HTMLElement | null)?.closest<HTMLButtonElement>(
+          "[data-experience-nav]"
+        );
+
+        if (!target) {
+          return;
+        }
+
+        event.preventDefault();
+
+        if (target.dataset.direction === "down") {
+          scrollToNextSection();
+        } else {
+          scrollToPreviousSection();
+        }
+      };
+
+      document.addEventListener("click", handleArrowClick);
       document.addEventListener("keydown", handleKeyDown);
       mainContainer.addEventListener("scroll", handleScroll, { passive: true });
 
@@ -189,8 +211,7 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
           scrollAnimationFrame = undefined;
         }
 
-        moreDownButton.removeEventListener("click", scrollToNextSection);
-        moreUpButton.removeEventListener("click", scrollToPreviousSection);
+        document.removeEventListener("click", handleArrowClick);
         document.removeEventListener("keydown", handleKeyDown);
         mainContainer.removeEventListener("scroll", handleScroll);
       };

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -62,152 +62,206 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
 </BaseLayout>
 
 <script is:inline data-astro-rerun>
-  document.addEventListener(
-    "astro:page-load",
-    () => {
-      const mainContainer = document.querySelector<HTMLElement>(".main-container");
-      const moreDownButton = document.querySelector<HTMLButtonElement>(
-        '[data-direction="down"]'
+  let teardown = null;
+
+  const setupNavigation = () => {
+    const mainContainer = document.querySelector(".main-container");
+    const moreDownButton = document.querySelector('[data-direction="down"]');
+    const moreUpButton = document.querySelector('[data-direction="up"]');
+
+    if (
+      !(mainContainer instanceof HTMLElement) ||
+      !(moreDownButton instanceof HTMLButtonElement) ||
+      !(moreUpButton instanceof HTMLButtonElement)
+    ) {
+      console.error("One or more elements could not be found in the document.");
+      return () => {};
+    }
+
+    const sections = Array.from(mainContainer.querySelectorAll("section"));
+
+    if (sections.length === 0) {
+      console.error("No sections were found inside the main container.");
+      return () => {};
+    }
+
+    let activeIndex = 0;
+    let sectionPositions = [];
+
+    const setArrowVisibility = (index) => {
+      moreUpButton.classList.toggle("invisible", index === 0);
+      moreDownButton.classList.toggle(
+        "invisible",
+        index === sections.length - 1
       );
-      const moreUpButton = document.querySelector<HTMLButtonElement>(
-        '[data-direction="up"]'
-      );
+    };
 
-      if (!mainContainer || !moreDownButton || !moreUpButton) {
-        console.error("One or more elements could not be found in the document.");
-        return;
-      }
-
-      const sections = Array.from(
-        mainContainer.querySelectorAll<HTMLElement>("section")
-      );
-
-      if (sections.length === 0) {
-        console.error("No sections were found inside the main container.");
-        return;
-      }
-
-      let sectionPositions = sections.map((section) => section.offsetTop);
-      let activeIndex = 0;
-
-      const setArrowVisibility = (index: number) => {
-        moreUpButton.classList.toggle("invisible", index === 0);
-        moreDownButton.classList.toggle(
-          "invisible",
-          index === sections.length - 1
+    const ensureSectionPositions = () => {
+      if (sectionPositions.length !== sections.length) {
+        sectionPositions = sections.map(
+          (section) => section.offsetTop - mainContainer.offsetTop
         );
-      };
+      }
+    };
 
-      const getSectionPositions = () =>
-        sections.map((section) => section.offsetTop);
+    const scrollToIndex = (index) => {
+      ensureSectionPositions();
+      const target = sectionPositions[index];
 
-      const scrollToIndex = (index: number) => {
-        const targetPosition = sectionPositions[index];
+      if (!Number.isFinite(target)) {
+        return;
+      }
 
-        if (typeof targetPosition !== "number") {
-          return;
-        }
+      activeIndex = index;
+      setArrowVisibility(index);
+      mainContainer.scrollTo({
+        top: target,
+        behavior: "smooth"
+      });
+    };
 
-        activeIndex = index;
-        setArrowVisibility(index);
+    const scrollToNextSection = () => {
+      const nextIndex = Math.min(activeIndex + 1, sections.length - 1);
 
-        mainContainer.scrollTo({
-          top: targetPosition,
-          behavior: "smooth"
-        });
-      };
+      if (nextIndex !== activeIndex) {
+        scrollToIndex(nextIndex);
+      }
+    };
 
-      const updateActiveIndexFromScroll = () => {
-        const scrollMiddle = mainContainer.scrollTop + mainContainer.clientHeight / 2;
-        let newIndex = 0;
+    const scrollToPreviousSection = () => {
+      const previousIndex = Math.max(activeIndex - 1, 0);
 
-        for (let index = 0; index < sectionPositions.length; index += 1) {
-          if (scrollMiddle >= sectionPositions[index]) {
-            newIndex = index;
-          } else {
-            break;
-          }
-        }
+      if (previousIndex !== activeIndex) {
+        scrollToIndex(previousIndex);
+      }
+    };
 
-        if (newIndex !== activeIndex) {
-          activeIndex = newIndex;
-          setArrowVisibility(newIndex);
-        }
-      };
-
-      const handleResize = () => {
-        sectionPositions = getSectionPositions();
-        updateActiveIndexFromScroll();
-      };
-
-      const scrollToNextSection = () => {
-        const nextIndex = Math.min(activeIndex + 1, sections.length - 1);
-
-        if (nextIndex !== activeIndex) {
-          scrollToIndex(nextIndex);
-        }
-      };
-
-      const scrollToPreviousSection = () => {
-        const previousIndex = Math.max(activeIndex - 1, 0);
-
-        if (previousIndex !== activeIndex) {
-          scrollToIndex(previousIndex);
-        }
-      };
-
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === "ArrowDown" || event.key === "PageDown") {
-          event.preventDefault();
-          scrollToNextSection();
-        } else if (event.key === "ArrowUp" || event.key === "PageUp") {
-          event.preventDefault();
-          scrollToPreviousSection();
-        }
-      };
-
-      const handleScroll = () => {
-        updateActiveIndexFromScroll();
-      };
-
-      const handleArrowClick = (event: MouseEvent) => {
+    const handleKeyDown = (event) => {
+      if (event.key === "ArrowDown" || event.key === "PageDown") {
         event.preventDefault();
+        scrollToNextSection();
+      } else if (event.key === "ArrowUp" || event.key === "PageUp") {
+        event.preventDefault();
+        scrollToPreviousSection();
+      }
+    };
 
-        if (event.currentTarget === moreDownButton) {
-          scrollToNextSection();
-        } else {
-          scrollToPreviousSection();
-        }
-      };
+    const handleArrowClick = (event) => {
+      event.preventDefault();
 
-      moreDownButton.addEventListener("click", handleArrowClick);
-      moreUpButton.addEventListener("click", handleArrowClick);
-      document.addEventListener("keydown", handleKeyDown);
-      mainContainer.addEventListener("scroll", handleScroll, { passive: true });
-      window.addEventListener("resize", handleResize);
+      if (event.currentTarget === moreDownButton) {
+        scrollToNextSection();
+      } else {
+        scrollToPreviousSection();
+      }
+    };
 
-      window.requestAnimationFrame(() => {
-        sectionPositions = getSectionPositions();
-        updateActiveIndexFromScroll();
-        setArrowVisibility(activeIndex);
+    const intersectionObserver = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) {
+            return;
+          }
+
+          const index = sections.indexOf(entry.target);
+
+          if (index === -1 || index === activeIndex) {
+            return;
+          }
+
+          activeIndex = index;
+          setArrowVisibility(activeIndex);
+        });
+      },
+      {
+        root: mainContainer,
+        threshold: 0.6
+      }
+    );
+
+    sections.forEach((section) => intersectionObserver.observe(section));
+
+    moreDownButton.addEventListener("click", handleArrowClick);
+    moreUpButton.addEventListener("click", handleArrowClick);
+    document.addEventListener("keydown", handleKeyDown);
+
+    window.requestAnimationFrame(() => {
+      ensureSectionPositions();
+
+      const visibleIndex = sections.findIndex((section, index) => {
+        const top = sectionPositions[index];
+        const bottom = top + section.clientHeight;
+        const scrollMiddle =
+          mainContainer.scrollTop + mainContainer.clientHeight / 2;
+
+        return scrollMiddle >= top && scrollMiddle < bottom;
       });
 
-      const cleanup = () => {
-        moreDownButton.removeEventListener("click", handleArrowClick);
-        moreUpButton.removeEventListener("click", handleArrowClick);
-        document.removeEventListener("keydown", handleKeyDown);
-        mainContainer.removeEventListener("scroll", handleScroll);
-        window.removeEventListener("resize", handleResize);
-      };
+      if (visibleIndex >= 0) {
+        activeIndex = visibleIndex;
+      }
 
-      document.addEventListener(
-        "astro:before-swap",
-        () => {
-          cleanup();
-        },
-        { once: true }
-      );
-    },
-    { once: true }
-  );
+      setArrowVisibility(activeIndex);
+    });
+
+    const handleResize = () => {
+      sectionPositions = [];
+      ensureSectionPositions();
+      const currentIndex = sections.findIndex((section, index) => {
+        const top = sectionPositions[index];
+        const bottom = top + section.clientHeight;
+        const scrollMiddle =
+          mainContainer.scrollTop + mainContainer.clientHeight / 2;
+
+        return scrollMiddle >= top && scrollMiddle < bottom;
+      });
+
+      if (currentIndex >= 0 && currentIndex !== activeIndex) {
+        activeIndex = currentIndex;
+      }
+
+      setArrowVisibility(activeIndex);
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    const cleanup = () => {
+      intersectionObserver.disconnect();
+      moreDownButton.removeEventListener("click", handleArrowClick);
+      moreUpButton.removeEventListener("click", handleArrowClick);
+      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("resize", handleResize);
+    };
+
+    const handleBeforeSwap = () => {
+      cleanup();
+    };
+
+    document.addEventListener("astro:before-swap", handleBeforeSwap, {
+      once: true
+    });
+
+    return () => {
+      cleanup();
+      document.removeEventListener("astro:before-swap", handleBeforeSwap);
+    };
+  };
+
+  const initializeNavigation = () => {
+    if (typeof teardown === "function") {
+      teardown();
+    }
+
+    teardown = setupNavigation();
+  };
+
+  if (document.readyState === "complete" || document.readyState === "interactive") {
+    initializeNavigation();
+  } else {
+    document.addEventListener("DOMContentLoaded", initializeNavigation, {
+      once: true
+    });
+  }
+
+  document.addEventListener("astro:page-load", initializeNavigation);
 </script>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -54,7 +54,7 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
       )
     }
   </main>
-  <div class="fixed left-1/2 bottom-[100px] z-10 -translate-x-1/2 md:bottom-10">
+  <div class="fixed left-1/2 bottom-[100px] z-10 -translate-x-1/2 md:bottom-10 flex flex-col items-center">
     <ArrowIcon direction="up" />
     <ArrowIcon direction="down" />
   </div>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -74,82 +74,83 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
         return;
       }
 
-      const updateArrowVisibility = () => {
-        const { scrollTop, scrollHeight, clientHeight } = mainContainer;
-        const atTop = scrollTop < 10;
-        const atBottom = scrollTop + clientHeight >= scrollHeight - 10;
+      const sections = Array.from(
+        mainContainer.querySelectorAll<HTMLElement>("section")
+      );
 
-        if (atTop) {
+      if (sections.length === 0) {
+        console.error("No sections were found inside the main container.");
+        return;
+      }
+
+      const getCurrentSectionIndex = () => {
+        const { scrollTop } = mainContainer;
+        let closestIndex = 0;
+        let smallestDistance = Number.POSITIVE_INFINITY;
+
+        sections.forEach((section, index) => {
+          const distance = Math.abs(section.offsetTop - scrollTop);
+
+          if (distance < smallestDistance) {
+            smallestDistance = distance;
+            closestIndex = index;
+          }
+        });
+
+        return closestIndex;
+      };
+
+      const updateArrowVisibility = () => {
+        const currentIndex = getCurrentSectionIndex();
+        const isAtFirstSection = currentIndex === 0;
+        const isAtLastSection = currentIndex === sections.length - 1;
+
+        if (isAtFirstSection) {
           moreUpButton.classList.add("invisible");
         } else {
           moreUpButton.classList.remove("invisible");
         }
 
-        if (atBottom) {
+        if (isAtLastSection) {
           moreDownButton.classList.add("invisible");
         } else {
           moreDownButton.classList.remove("invisible");
         }
       };
 
-      let lastScrollTop = 0;
-      let isScrolling = false;
-      let scrollTimeout: ReturnType<typeof setTimeout> | undefined;
+      const scrollToSection = (targetIndex: number) => {
+        const targetSection = sections[targetIndex];
 
-      const handleScroll = () => {
-        if (isScrolling) {
+        if (!targetSection) {
           return;
         }
 
-        const { scrollTop } = mainContainer;
-        const scrollingUp = scrollTop < lastScrollTop;
+        mainContainer.scrollTo({
+          top: targetSection.offsetTop,
+          behavior: "smooth"
+        });
 
-        if (scrollingUp) {
-          moreDownButton.classList.remove("invisible");
-        }
-
-        updateArrowVisibility();
-        lastScrollTop = scrollTop <= 0 ? 0 : scrollTop;
+        window.requestAnimationFrame(() => {
+          updateArrowVisibility();
+        });
       };
 
       const scrollToNextSection = () => {
-        if (isScrolling) {
-          return;
+        const currentIndex = getCurrentSectionIndex();
+        const nextIndex = Math.min(currentIndex + 1, sections.length - 1);
+
+        if (nextIndex !== currentIndex) {
+          scrollToSection(nextIndex);
         }
-
-        isScrolling = true;
-        const { scrollTop, clientHeight } = mainContainer;
-        const targetScrollTop = Math.ceil(scrollTop / clientHeight) * clientHeight + clientHeight;
-
-        mainContainer.scrollTo({
-          top: targetScrollTop,
-          behavior: "smooth"
-        });
-
-        window.setTimeout(() => {
-          updateArrowVisibility();
-          isScrolling = false;
-        }, 500);
       };
 
       const scrollToPreviousSection = () => {
-        if (isScrolling) {
-          return;
+        const currentIndex = getCurrentSectionIndex();
+        const previousIndex = Math.max(currentIndex - 1, 0);
+
+        if (previousIndex !== currentIndex) {
+          scrollToSection(previousIndex);
         }
-
-        isScrolling = true;
-        const { scrollTop, clientHeight } = mainContainer;
-        const targetScrollTop = Math.floor(scrollTop / clientHeight) * clientHeight - clientHeight;
-
-        mainContainer.scrollTo({
-          top: targetScrollTop,
-          behavior: "smooth"
-        });
-
-        window.setTimeout(() => {
-          updateArrowVisibility();
-          isScrolling = false;
-        }, 500);
       };
 
       const handleKeyDown = (event: KeyboardEvent) => {
@@ -162,28 +163,36 @@ const formattedExperienceData = formatExperienceData(workExperience as WorkExper
         }
       };
 
-      const debouncedScrollHandler = () => {
-        if (scrollTimeout) {
-          window.clearTimeout(scrollTimeout);
+      let scrollAnimationFrame: number | undefined;
+
+      const handleScroll = () => {
+        if (scrollAnimationFrame) {
+          return;
         }
-        scrollTimeout = window.setTimeout(handleScroll, 10);
+
+        scrollAnimationFrame = window.requestAnimationFrame(() => {
+          updateArrowVisibility();
+          scrollAnimationFrame = undefined;
+        });
       };
 
       moreDownButton.addEventListener("click", scrollToNextSection);
       moreUpButton.addEventListener("click", scrollToPreviousSection);
       document.addEventListener("keydown", handleKeyDown);
-      mainContainer.addEventListener("scroll", debouncedScrollHandler, { passive: true });
+      mainContainer.addEventListener("scroll", handleScroll, { passive: true });
 
       updateArrowVisibility();
 
       const cleanup = () => {
-        if (scrollTimeout) {
-          window.clearTimeout(scrollTimeout);
+        if (scrollAnimationFrame) {
+          window.cancelAnimationFrame(scrollAnimationFrame);
+          scrollAnimationFrame = undefined;
         }
+
         moreDownButton.removeEventListener("click", scrollToNextSection);
         moreUpButton.removeEventListener("click", scrollToPreviousSection);
         document.removeEventListener("keydown", handleKeyDown);
-        mainContainer.removeEventListener("scroll", debouncedScrollHandler);
+        mainContainer.removeEventListener("scroll", handleScroll);
       };
 
       document.addEventListener(


### PR DESCRIPTION
## Summary
- remove absolute positioning from the CV navigation arrows so the buttons can be clicked again
- align the floating arrow container with flex utilities to keep the arrows centered and stacked

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5fbdd9370832c952c4fbdd88f2e1d